### PR TITLE
compile ranom_bytea en recent PG

### DIFF
--- a/postgresql/random_bytea/random_bytea--1.0.sql
+++ b/postgresql/random_bytea/random_bytea--1.0.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION random_bytea(integer) RETURNS bytea
 	AS 'random_bytea','random_bytea'
-	LANGUAGE 'C' STRICT;
+	LANGUAGE C STRICT;
 
 COMMENT ON FUNCTION random_bytea(integer) IS 'Generate n random bytes of garbage, returned as bytea';


### PR DESCRIPTION
I had the following error in PostgreSQL 11:
```sql
# CREATE EXTENSION random_bytea;
ERROR:  language "C" does not exist
```

Works fine without the quotes.

Thanks for the extension!